### PR TITLE
chore(ts): remove @types/next-auth

### DIFF
--- a/config.server.ts
+++ b/config.server.ts
@@ -1,4 +1,4 @@
-import Providers from "next-auth/providers";
+import Providers, { AppProviders } from "next-auth/providers";
 import { prisma, resolvedConfig } from "./utils.server";
 
 /**
@@ -6,7 +6,7 @@ import { prisma, resolvedConfig } from "./utils.server";
  * https://next-auth.js.org/configuration/providers
  */
 
-const providers = [];
+const providers: AppProviders = [];
 
 if (resolvedConfig.useLocalAuth) {
   providers.push(

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "markdown-it": "^12.0.6",
     "milligram": "^1.4.1",
     "next": "^10.0.5",
-    "next-auth": "3.14.7",
+    "next-auth": "3.15.5",
     "postcss": "^8.2.10",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -53,7 +53,6 @@
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-proposal-decorators": "^7.12.12",
-    "@types/next-auth": "^3.13.0",
     "@types/node": "^14.14.21",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,16 +1237,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
 
-"@types/next-auth@^3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@types/next-auth/-/next-auth-3.13.0.tgz#c933bcc4259262959544df24bbc8528e3548fa26"
-  integrity sha512-zkEVDyoKgRsHm3KUaZoOGSThTS9h0+HbFZctiYbB5MMU6/pUZuF5ozWrVG00jotQJuSEIlPWzdCIXKlaHctJgw==
-  dependencies:
-    "@types/node" "*"
-    "@types/react" "*"
-    jose "^1.28.0"
-    typeorm "^0.2.31"
-
 "@types/node@*", "@types/node@^14.14.21":
   version "14.14.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
@@ -3542,7 +3532,7 @@ joi@^13.1.2:
     isemail "3.x.x"
     topo "3.x.x"
 
-jose@^1.27.2, jose@^1.28.0:
+jose@^1.27.2:
   version "1.28.1"
   resolved "https://registry.yarnpkg.com/jose/-/jose-1.28.1.tgz#34a0f851a534be59ffab82a6e8845f6874e8c128"
   integrity sha512-6JK28rFu5ENp/yxMwM+iN7YeaInnY9B9Bggjkz5fuwLiJhbVrl2O4SJr65bdNBPl9y27fdC3Mymh+FVCvozLIg==
@@ -4053,10 +4043,10 @@ new-github-issue-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/new-github-issue-url/-/new-github-issue-url-0.2.1.tgz#e17be1f665a92de465926603e44b9f8685630c1d"
   integrity sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA==
 
-next-auth@3.14.7:
-  version "3.14.7"
-  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-3.14.7.tgz#3718fc5265851fbf52838fb3165a7a2a58b59d06"
-  integrity sha512-Z3kGvmdpr3uaSMyijRytHYpUajPAhpLJjlze99awmXD20pEV7yrtrQmrsgEnhUpASaVQYranexR3k6i+V0SZ6g==
+next-auth@3.15.5:
+  version "3.15.5"
+  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-3.15.5.tgz#e129bc04c7a31417877647cb9712f906ce69b7dd"
+  integrity sha512-oi95on/QwynQOfNu+9XDAohdt5hTF1F44qUfRFeX5PWghlU8CIcV5smmVV6VjejEFL5Knddqkyv9uMzYuLR70A==
   dependencies:
     crypto-js "^4.0.0"
     futoin-hkdf "^1.3.2"
@@ -5911,7 +5901,7 @@ typegraphql-prisma@^0.9.4:
     ts-morph "^9.1.0"
     tslib "^2.1.0"
 
-typeorm@^0.2.30, typeorm@^0.2.31:
+typeorm@^0.2.30:
   version "0.2.32"
   resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.32.tgz#544dbfdfe0cd0887548d9bcbd28527ea4f4b3c9b"
   integrity sha512-LOBZKZ9As3f8KRMPCUT2H0JZbZfWfkcUnO3w/1BFAbL/X9+cADTF6bczDGGaKVENJ3P8SaKheKmBgpt5h1x+EQ==


### PR DESCRIPTION
Maintainer of `next-auth` here. Nice project!

As of `3.15.x`, `next-auth` comes with built-in TypeScript support! :tada: I removed the now obsolete `@types/next-auth` package, in favor of the built-in types. Hope you like it :slightly_smiling_face: 