### PR TITLE
Inherit font-family on controls

### DIFF
--- a/widget/components/Reply.svelte
+++ b/widget/components/Reply.svelte
@@ -82,6 +82,7 @@
     padding: 0.5em;
     border-radius: 4px;
     outline: none;
+    font-family: inherit;
   }
 
   textarea {
@@ -107,6 +108,7 @@
     cursor: pointer;
     border-radius: 2px;
     font-weight: bold;
+    font-family: inherit;
   }
 
   .cusdis-field {


### PR DESCRIPTION
Hi there, thanks for this project, really cool!

I noticed that the fonts on the controls are a bit inconsistent:

- Arial on the `<button>` and `<input>`s 
- monospace on the `<textarea>`

![Screen Shot 2021-04-21 at 21 28 38](https://user-images.githubusercontent.com/1935696/115610139-beac3000-a2e8-11eb-8dbb-326a3e412ca9.png)

This PR allows the `font-family` to be inherited on all controls from the font set on the page, making the design consistent:

![Screen Shot 2021-04-21 at 21 28 31](https://user-images.githubusercontent.com/1935696/115610169-c966c500-a2e8-11eb-8343-10fc66807ca2.png)
