### PR TITLE
Send Email with HTML content as well

### DIFF
--- a/pages/dashboard/project/[projectId].tsx
+++ b/pages/dashboard/project/[projectId].tsx
@@ -315,7 +315,7 @@ function Settings(props: {
   data-page-url="{{ PAGE_URL }}"
   data-page-title="{{ PAGE_TITLE }}"
 ></div>
-<script async src="${location.origin}/js/cusdis.es.js"></script>
+<script async defer src="${location.origin}/js/cusdis.es.js"></script>
 `}
             </code>
           </Box>}

--- a/utils.server.ts
+++ b/utils.server.ts
@@ -63,7 +63,7 @@ export const resolvedConfig = {
       user: process.env.SMTP_USER as EnvVariable,
       pass: process.env.SMTP_PASSWORD as EnvVariable
     },
-    senderAddress: process.env.SMTP_SENDER as EnvVariable
+    senderAddress: process.env.SMTP_SENDER as EnvVariable || 'Cusdis Notification<notification@cusdis.com>'
   },
   sendgrid: {
     apiKey: process.env.SENDGRID_API_KEY as EnvVariable


### PR DESCRIPTION
Reads the config from env var to send emails with HTML body just as send gird.

Eventually we should make the configuration in a page. This will be tracked by #47 and not in the scope of this PR.