### PR TITLE
fix: pageUrl and pageTitle did not insert when create comment

### DIFF
--- a/pages/api/open/comments.ts
+++ b/pages/api/open/comments.ts
@@ -39,6 +39,8 @@ export default async function handler(
         content: body.content,
         email: body.email,
         nickname: body.nickname,
+        pageTitle: body.pageTitle,
+        pageUrl: body.pageUrl
       },
       body.parentId,
     )

--- a/pages/dashboard/project/[projectId].tsx
+++ b/pages/dashboard/project/[projectId].tsx
@@ -126,7 +126,7 @@ function CommentComponent(props: {
   return (
     <Box key={comment.id} pl={!props.isRoot ? 4 : 0}>
       <HStack spacing={2}>
-        <Link color="gray.500" href={comment.page.url}>{comment.page.slug}</Link>
+        <Link color="gray.500" href={comment.page.url}>{comment.page.title}</Link>
         <Spacer />
 
         {comment.moderatorId && <Tag colorScheme="cyan" size="sm">MOD</Tag>}


### PR DESCRIPTION
**Root Cause:**
the `addcomment` in the comment handler does not pass the `pageTitle` & `pageUrl`, so when calling the` upsertPage` methods in the `comment.service`, it will not receive the params in `body`. when getting the comment list in the dashboard, they will be null in the response and the link is empty.



**Enhancement:**
personally, I think it will be better if show the page title instead of the slug in the comment list, sometimes, the user may need to know the origin of the comment, and it will be cleaner than the slug. 🤔 


**compare:**
before | after
---- | ----
<img width="1433" alt="截屏2021-04-27 14 05 41" src="https://user-images.githubusercontent.com/20736452/116193397-ddd01500-a761-11eb-84d4-4bc94c8b5910.png">|<img width="1066" alt="截屏2021-04-27 14 02 33" src="https://user-images.githubusercontent.com/20736452/116193411-e58fb980-a761-11eb-8149-699265adc3ce.png">
<img width="976" alt="截屏2021-04-27 14 06 00" src="https://user-images.githubusercontent.com/20736452/116193441-f4766c00-a761-11eb-8899-af0722c68179.png">|<img width="980" alt="截屏2021-04-27 14 03 43" src="https://user-images.githubusercontent.com/20736452/116193449-f6d8c600-a761-11eb-8a5b-5fc3e1d8bfce.png">




