### PR TITLE
Dev

### DIFF
--- a/widget/Widget.svelte
+++ b/widget/Widget.svelte
@@ -4,6 +4,7 @@
   import Comment from './components/Comment.svelte'
   import Reply from './components/Reply.svelte'
   import { t } from './i18n'
+  import './theme.css'
 
   export let attrs
   export let commentsResult
@@ -15,6 +16,8 @@
   let message = ''
 
   let error
+
+  let theme = attrs.theme || 'auto'
 
   const api = axios.create({
     baseURL: attrs.host,
@@ -58,7 +61,7 @@
 </script>
 
 {#if !error}
-  <div class="comment-main">
+  <div class={`comment-main ${theme}`}>
     {#if message}
       <div class="cusdis-message">
         {message}
@@ -69,7 +72,10 @@
 
     <div>
       {#if loadingComments}
-        <div style="text-align: center; font-size: .8em;">
+        <div
+          class="cusdis-loading-text"
+          style="text-align: center; font-size: .8em;"
+        >
           {t('loading')}...
         </div>
       {:else}
@@ -103,13 +109,18 @@
     margin-top: 1em;
     font-size: 0.8em;
     text-align: center;
+    color: var(--color-text-default);
+  }
+
+  .cusdis-loading-text {
+    color: var(--color-text-default);
   }
   .comment-main {
     font-size: 17px;
   }
   .cusdis-message {
-    background-color: #046582;
-    color: #fff;
+    background-color: var(--color-message-bg);
+    color: var(--color-message-text);
     padding: 0.5em;
     font-size: 1em;
   }
@@ -128,6 +139,6 @@
   }
 
   .cusdis-pagination-button.selected {
-    background-color: #ddd;
+    background-color: var(--color-pagination-bg-selected);
   }
 </style>

--- a/widget/Widget.svelte
+++ b/widget/Widget.svelte
@@ -61,7 +61,7 @@
 </script>
 
 {#if !error}
-  <div class={`comment-main ${theme}`}>
+  <div class={`comment-main ${theme !== 'light' ? theme : ''}`}>
     {#if message}
       <div class="cusdis-message">
         {message}

--- a/widget/components/Comment.svelte
+++ b/widget/components/Comment.svelte
@@ -1,31 +1,53 @@
 <script>
-  import { getContext } from "svelte";
-import { t } from "../i18n";
+  import { getContext } from 'svelte'
+  import { t } from '../i18n'
 
-  import Reply from "./Reply.svelte";
-  export let comment;
-  export let showReplyForm = false;
+  import Reply from './Reply.svelte'
+  export let comment
+  export let showReplyForm = false
 
   const { showIndicator } = getContext('attrs')
 </script>
 
-<div class:cusdis-padding={true} class:cusdis-indicator={showIndicator} style="margin-top: 2em; margin-bottom: 2em;">
+<div
+  class:cusdis-padding={true}
+  class:cusdis-indicator={showIndicator}
+  style="margin-top: 2em; margin-bottom: 2em;"
+>
   <div style="margin-bottom: .5em;">
-    <div class="cusdis-comment-nickname cusdis-inline cusdis-font-bold">{comment.by_nickname}</div>
+    <div class="cusdis-comment-nickname cusdis-inline cusdis-font-bold">
+      {comment.by_nickname}
+    </div>
     {#if comment.moderatorId}
       <span class="mod">MOD</span>
     {/if}
-    <div class="cusdis-comment-date cusdis-inline">{comment.parsedCreatedAt}</div>
+    <div class="cusdis-comment-date cusdis-inline">
+      {comment.parsedCreatedAt}
+    </div>
   </div>
 
-  <div class="cusdis-comment-content" style="margin-bottom: .5em;">{@html comment.parsedContent}</div>
+  <div class="cusdis-comment-content" style="margin-bottom: .5em;">
+    {@html comment.parsedContent}
+  </div>
 
   <div style="margin-top: .25em; margin-bottom: .25em;">
-    <button style="" type="button" on:click={_ => { showReplyForm = true }} class="cusdis-link-btn">{t('reply_btn')}</button>
+    <button
+      style=""
+      type="button"
+      on:click={(_) => {
+        showReplyForm = true
+      }}
+      class="cusdis-link-btn">{t('reply_btn')}</button
+    >
   </div>
 
   {#if showReplyForm}
-    <Reply parentId={comment.id} onSuccess={() => { showReplyForm = false }} />
+    <Reply
+      parentId={comment.id}
+      onSuccess={() => {
+        showReplyForm = false
+      }}
+    />
   {/if}
 
   {#if comment.replies.data.length > 0}
@@ -41,7 +63,8 @@ import { t } from "../i18n";
   }
 
   .cusdis-indicator {
-    border-left: 2px solid #ddd;
+    border-left: 2px solid;
+    border-left-color: var(--color-comment-indicator-border);
   }
   .cusdis-font-bold {
     font-weight: bold;
@@ -53,15 +76,16 @@ import { t } from "../i18n";
 
   .cusdis-comment-nickname {
     font-size: 1em;
+    color: var(--color-comment-username-text);
   }
 
   .cusdis-comment-content {
-    color: rgba(0, 0, 0, 0.8);
+    color: var(--color-text-default);
     font-size: 1em;
   }
 
   .cusdis-comment-date {
-    color: rgba(0, 0, 0, 0.8);
+    color: var(--color-text-default);
     font-size: 0.8em;
   }
 
@@ -73,15 +97,16 @@ import { t } from "../i18n";
     margin: 0;
     background: none;
     padding: 0;
+    color: var(--color-text-default);
   }
 
   .mod {
-    background-color: #ddd;
-    font-size: .8em;
+    background-color: var(--color-mod-bg);
+    font-size: 0.8em;
     box-sizing: border-box;
-    padding: .15em .4em;
+    padding: 0.15em 0.4em;
     border-radius: 4px;
     font-weight: bold;
-    color: rgba(0,0, 0, .8);
+    color: var(--color-mod-text);
   }
 </style>

--- a/widget/components/Reply.svelte
+++ b/widget/components/Reply.svelte
@@ -1,36 +1,36 @@
 <script>
-  import { getContext } from "svelte";
-import { t } from "../i18n";
-  export let parentId;
+  import { getContext } from 'svelte'
+  import { t } from '../i18n'
+  export let parentId
 
   // form data
-  let content = "";
-  let nickname = "";
-  let email = "";
+  let content = ''
+  let nickname = ''
+  let email = ''
 
-  let loading = false;
+  let loading = false
 
-  export let onSuccess;
+  export let onSuccess
 
-  const api = getContext("api");
+  const api = getContext('api')
   const setMessage = getContext('setMessage')
-  const { appId, pageId, pageUrl, pageTitle } = getContext("attrs");
-  const refresh = getContext("refresh");
+  const { appId, pageId, pageUrl, pageTitle } = getContext('attrs')
+  const refresh = getContext('refresh')
 
   async function addComment() {
     if (!content) {
-      alert(t('content_is_required'));
-      return;
+      alert(t('content_is_required'))
+      return
     }
 
     if (!nickname) {
-      alert(t('nickname_is_required'));
-      return;
+      alert(t('nickname_is_required'))
+      return
     }
 
     try {
-      loading = true;
-      const res = await api.post("/api/open/comments", {
+      loading = true
+      const res = await api.post('/api/open/comments', {
         appId,
         pageId,
         content,
@@ -39,20 +39,20 @@ import { t } from "../i18n";
         parentId,
         pageUrl,
         pageTitle,
-      });
-      await refresh();
-      teardown();
+      })
+      await refresh()
+      teardown()
       setMessage(t('comment_has_been_sent'))
     } finally {
-      loading = false;
+      loading = false
     }
   }
 
   function teardown() {
-    content = "";
-    nickname = "";
-    email = "";
-    onSuccess && onSuccess();
+    content = ''
+    nickname = ''
+    email = ''
+    onSuccess && onSuccess()
   }
 </script>
 
@@ -71,7 +71,14 @@ import { t } from "../i18n";
   </div>
 
   <div class="cusdis-field">
-    <button cusdis-disabled={loading} class="submit-btn" class:cusdis-disabled={loading} on:click={addComment}>{ loading ? t('sending') : t('post_comment') }</button>
+    <button
+      cusdis-disabled={loading}
+      class="submit-btn"
+      class:cusdis-disabled={loading}
+      on:click={addComment}
+    >
+      {loading ? t('sending') : t('post_comment')}
+    </button>
   </div>
 </div>
 
@@ -79,7 +86,9 @@ import { t } from "../i18n";
   textarea,
   input {
     width: 100%;
-    border: 2px solid #ddd;
+    border: 2px solid;
+    border-color: var(--color-input-border);
+    background: none;
     padding: 0.5em;
     border-radius: 4px;
     outline: none;
@@ -94,7 +103,7 @@ import { t } from "../i18n";
   }
 
   .cusdis-disabled {
-    background-color: rgba(0, 0, 0, .5);
+    background-color: var(--color-btn-bg-disabled);
     cursor: not-allowed;
   }
 
@@ -113,9 +122,9 @@ import { t } from "../i18n";
   }
 
   .submit-btn {
-    background-color: #ddd;
+    background-color: var(--color-btn-bg-default);
     border: 0px;
-    color: rgba(0, 0, 0, 0.8);
+    color: var(--color-btn-text);
     border-radius: 0;
     padding: 0.5em 1em;
     cursor: pointer;

--- a/widget/theme.css
+++ b/widget/theme.css
@@ -1,0 +1,64 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.comment-main {
+  --color-text-default: rgba(0, 0, 0, 0.8);
+  --color-input-border: #ddd;
+  --color-btn-text: rgba(0, 0, 0, 0.8);
+  --color-btn-bg-default: #ddd;
+  --color-btn-bg-disabled: rgba(0, 0, 0, 0.5);
+  --color-message-text: #fff;
+  --color-message-bg: #046582;
+  --color-pagination-bg-selected: #ddd;
+  --color-comment-indicator-border: #ddd;
+  --color-comment-username-text: #000;
+  --color-mod-text: rgba(0, 0, 0, 0.8);
+  --color-mod-bg: #ddd;
+}
+
+.dark {
+  --color-text-default: rgba(243, 244, 246, 0.8);
+  --color-input-border: rgb(229, 231, 235);
+  --color-btn-text: rgba(55, 65, 81, 0.8);
+  --color-btn-bg-default: rgb(229, 231, 235);
+  --color-btn-bg-disabled: rgba(55, 65, 81, 0.5);
+  --color-message-text: rgba(243, 244, 246, 0.8);
+  --color-message-bg: #046582; /* no need change for now */
+  --color-pagination-bg-selected: rgb(229, 231, 235);
+  --color-comment-indicator-border: rgb(229, 231, 235);
+  --color-comment-username-text: #fff;
+  --color-mod-text: rgba(55, 65, 81, 0.8);
+  --color-mod-bg: rgb(229, 231, 235);
+}
+
+.auto {
+  --color-text-default: rgba(0, 0, 0, 0.8);
+  --color-input-border: #ddd;
+  --color-btn-text: rgba(0, 0, 0, 0.8);
+  --color-btn-bg-default: #ddd;
+  --color-btn-bg-disabled: rgba(0, 0, 0, 0.5);
+  --color-message-text: #fff;
+  --color-message-bg: #046582;
+  --color-pagination-bg-selected: #ddd;
+  --color-comment-indicator-border: #ddd;
+  --color-comment-username-text: #000;
+  --color-mod-text: rgba(0, 0, 0, 0.8);
+  --color-mod-bg: #ddd;
+}
+@media (prefers-color-scheme: dark) {
+  .auto {
+    --color-text-default: rgba(243, 244, 246, 0.8);
+    --color-input-border: rgb(229, 231, 235);
+    --color-btn-text: rgba(55, 65, 81, 0.8);
+    --color-btn-bg-default: rgb(229, 231, 235);
+    --color-btn-bg-disabled: rgba(55, 65, 81, 0.5);
+    --color-message-text: rgba(243, 244, 246, 0.8);
+    --color-message-bg: #046582; /* no need change for now */
+    --color-pagination-bg-selected: rgb(229, 231, 235);
+    --color-comment-indicator-border: rgb(229, 231, 235);
+    --color-comment-username-text: #fff;
+    --color-mod-text: rgba(55, 65, 81, 0.8);
+    --color-mod-bg: rgb(229, 231, 235);
+  }
+}


### PR DESCRIPTION
This PR is trying to add theme support for cusdis, currently support dark theme and auto (based on browser `prefers-color-scheme`)

Usage: 

```
<div id="cusdis_thread"
  data-host="https://cusdis.com"
  data-app-id="{{ APP_ID }}"
  data-page-id="{{ PAGE_ID }}"
  data-page-url="{{ PAGE_URL }}"
  data-page-title="{{ PAGE_TITLE }}"
  data-theme="[dark | light | auto]"
></div>
<script async defer src="https://cusdis.com/js/cusdis.es.js"></script>
```

I put all the colors into `theme.css` to make it easier to modify in the future.

This PR also formatted the code style (only the widget part), no more semi colons.