### PR TITLE
fix(style): loading text color

### DIFF
--- a/widget/Widget.svelte
+++ b/widget/Widget.svelte
@@ -101,7 +101,7 @@
 
     <div class="mt-4">
       {#if loadingComments}
-        <div>
+        <div class="text-gray-900 dark:text-gray-100">
           {t('loading')}...
         </div>
       {:else}


### PR DESCRIPTION
The visibility of loading text was poor in dark mode, so this has been fixed. 

`Loading...`

[![](https://i.gyazo.com/40fd834decca089e9c0d34e6d10efbbd.gif)](https://gyazo.com/40fd834decca089e9c0d34e6d10efbbd)
