### PR TITLE
feat: hide pagination if no comments

### DIFF
--- a/pages/dashboard/project/[projectId].tsx
+++ b/pages/dashboard/project/[projectId].tsx
@@ -190,7 +190,7 @@ function ProjectPage(props: {
   const getCommentsQuery = useQuery(['getComments', { projectId: router.query.projectId as string, page }], getComments, {
   })
 
-  const { commentCount = 0, pageCount = 1 } = getCommentsQuery.data || {}
+  const { commentCount = 0, pageCount = 0 } = getCommentsQuery.data || {}
 
   return (
     <>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1356263/131350220-83cfe2a9-3600-44c0-8138-10078cfb810c.png)

Currently cusdis dashboard will display a navigation component even if there are no any comments, which looks weird. It may look better if we hide it.