### PR TITLE
Fix process crash after failing to send emails.

### DIFF
--- a/service/notification.service.ts
+++ b/service/notification.service.ts
@@ -86,9 +86,9 @@ export class NotificationService extends RequestScopeService {
       }
 
       try {
-        this.emailService.send(msg)
+        await this.emailService.send(msg)
       } catch (e) {
-        // TODO:
+        console.log("unable to send email:", e)
       }
     }
   }


### PR DESCRIPTION
The call to `this.emailService.send` is missing an `await` so exceptions thrown from `send` terminate the node process.