### PR TITLE
fix outline style

### DIFF
--- a/widget/Widget.svelte
+++ b/widget/Widget.svelte
@@ -99,7 +99,7 @@
 
     <div class="my-8" />
 
-    <div class="mt-4">
+    <div class="mt-4 px-1">
       {#if loadingComments}
         <div class="text-gray-900 dark:text-gray-100">
           {t('loading')}...

--- a/widget/components/Reply.svelte
+++ b/widget/components/Reply.svelte
@@ -59,7 +59,7 @@
 
 <div class="grid grid-cols-1 gap-4">
   <div class="grid grid-cols-2 gap-4">
-    <div>
+    <div class="px-1">
       <label class="mb-2 block dark:text-gray-200" for="nickname">{t('nickname')}</label>
       <input
         name="nickname"
@@ -68,7 +68,7 @@
         bind:value={nickname}
       />
     </div>
-    <div>
+    <div class="px-1">
       <label class="mb-2 block dark:text-gray-200" for="email">{t('email')}</label>
       <input
         name="email"
@@ -79,7 +79,7 @@
     </div>
   </div>
 
-  <div>
+  <div class="px-1">
     <label class="mb-2 block dark:text-gray-200" for="reply_content">{t('reply_placeholder')}</label>
     <textarea
       name="reply_content"
@@ -88,9 +88,9 @@
     />
   </div>
 
-  <div>
+  <div class="px-1">
     <button
-      
+
       class="text-sm bg-gray-200 p-2 px-4 font-bold"
       class:cusdis-disabled={loading}
       on:click={addComment}>{loading ? t('sending') : t('post_comment')}</button


### PR DESCRIPTION
fix: #140
The outline of inputs and textarea was cut by wrapper div. this pr fix it by adding padding to wrapper div, it's more safe than change ancestor div's overflow property.
 
Before:
<img width="831" alt="08e8ccb0d6dd64570ec1689fffe90cd" src="https://user-images.githubusercontent.com/11043540/143522590-3e7df418-6299-4f52-8a9d-ef649734b3f4.png">

After:
<img width="862" alt="f0f64fbdd5ffe9cb0a07177ec8550af" src="https://user-images.githubusercontent.com/11043540/143522611-42fa568b-dd56-425e-9373-4392c50ddebd.png">
