### PR TITLE
add title for input box in widgets

### DIFF
--- a/widget/components/Reply.svelte
+++ b/widget/components/Reply.svelte
@@ -65,6 +65,7 @@
         name="nickname"
         class="w-full p-2 border border-gray-200 bg-transparent dark:text-gray-100 dark:outline-none"
         type="text"
+        title={t('nickname')}
         bind:value={nickname}
       />
     </div>
@@ -74,6 +75,7 @@
         name="email"
         class="w-full p-2 border border-gray-200 bg-transparent  dark:text-gray-100 dark:outline-none"
         type="email"
+        title={t('email')}
         bind:value={email}
       />
     </div>
@@ -84,6 +86,7 @@
     <textarea
       name="reply_content"
       class="w-full p-2 border border-gray-200 h-24 bg-transparent dark:text-gray-100 dark:outline-none"
+      title={t('reply_placeholder')}
       bind:value={content}
     />
   </div>


### PR DESCRIPTION
to improve accessibility, otherwise screen readers will be unable to give information to people with visual impairment.
或者说，通过加入`title`属性改善可访问性，具体效果如何可以自己用[这个扩展](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn)试一试