### PR TITLE
fix: respond to the same method for approve API

### DIFF
--- a/pages/api/open/approve.ts
+++ b/pages/api/open/approve.ts
@@ -17,7 +17,7 @@ export default async function handler(
 
   const tokenService = new TokenService()
 
-  if (req.method === 'GET') {
+  if (req.method === 'POST') {
     const { token } = req.query as {
       token?: string
     }


### PR DESCRIPTION
As in the case of https://github.com/djyde/cusdis/blob/cb4048120a926d63a939fa1fed29c43833f60be7/pages/open/approve.tsx#L15