### PR TITLE
fix: styles under dark mode

### DIFF
--- a/widget/Widget.svelte
+++ b/widget/Widget.svelte
@@ -27,10 +27,6 @@
     message = msg
   }
 
-  $: {
-    document.documentElement.style.setProperty('color-scheme', theme)
-  }
-
   onMount(() => {
 
     function onMessage(e) {

--- a/widget/components/Reply.svelte
+++ b/widget/components/Reply.svelte
@@ -93,8 +93,7 @@
 
   <div class="px-1">
     <button
-
-      class="text-sm bg-gray-200 p-2 px-4 font-bold dark:bg-transparent dark:border dark:border-gray-100"
+      class="text-sm dark:text-gray-100 bg-gray-200 p-2 px-4 font-bold dark:bg-transparent dark:border dark:border-gray-100"
       class:cusdis-disabled={loading}
       on:click={addComment}>{loading ? t('sending') : t('post_comment')}</button
     >


### PR DESCRIPTION
Hi, just found 2 places that annoyed me under dark mode, therefore I made some fixes.

## remove the default style from browsers under dark mode

I found the `color-scheme: dark/light` on the HTML element will apply the default style from browsers. 

As the image shows below, you can see a darker gray background behind the form region, comparing the lighter gray background of the user's site.

![image](https://github.com/djyde/cusdis/assets/3401641/e151baa6-db96-40f7-95a8-2d58698bbff2)

## fix the text color of the submit button

After removing the `color-scheme: dark/light` style on the HTML element, the text color of the submit button will still be white under dark mode. So I added a new class `dark:text-gray-100` on the button to correct the text color.


