### PR TITLE
Use bash as script shell for env vars in scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+script-shell=bash


### PR DESCRIPTION
When using zsh, environment variables will not work when running scripts in package.json. 

If you use yarn, you have to run it with bash manually. 