### PR TITLE
fix approve by email 405

### DIFF
--- a/pages/api/open/approve.ts
+++ b/pages/api/open/approve.ts
@@ -83,7 +83,7 @@ export default async function handler(
       })
     }
 
-    await usageService.incr(UsageLabel.QuickApprove)
+    await usageService.incr(UsageLabel.QuickApprove, tokenBody.owner.id)
 
     res.json({
       message: 'success'

--- a/service/usage.service.ts
+++ b/service/usage.service.ts
@@ -3,26 +3,26 @@ import { UsageLabel } from "../config.common";
 import { prisma } from "../utils.server";
 
 export class UsageService extends RequestScopeService {
-  async incr(label: UsageLabel) {
-    const session = await this.getSession()
+  async incr(label: UsageLabel, ownerId = null) {
+    const uid = ownerId || (await this.getSession()).uid
 
     await prisma.usage.upsert({
       where: {
         userId_label: {
-          userId: session.uid,
+          userId: uid,
           label,
-        }
+        },
       },
       create: {
-        userId: session.uid,
+        userId: uid,
         label,
-        count: 1
+        count: 1,
       },
       update: {
         count: {
-          increment: 1
-        }
-      }
+          increment: 1,
+        },
+      },
     })
   }
 }


### PR DESCRIPTION
There was no session ID for directly coming into the app via email, so prisma was failing the write due to missing uid.

This fills in the uid instead from the token owner ID for this case.