### PR TITLE
fix: use constant-time comparison for auth token (CWE-208)

### DIFF
--- a/config.server.ts
+++ b/config.server.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'crypto'
 import Providers, { AppProviders } from 'next-auth/providers'
 import { prisma, resolvedConfig } from './utils.server'
 
@@ -27,7 +28,8 @@ if (resolvedConfig.useLocalAuth) {
       async authorize(credentials: { username: string; password: string }) {
         if (
           credentials.username === process.env.USERNAME &&
-          credentials.password === process.env.PASSWORD
+          process.env.PASSWORD &&
+          (() => { try { return timingSafeEqual(Buffer.from(credentials.password), Buffer.from(process.env.PASSWORD)) } catch { return false } })()
         ) {
           const user = await prisma.user.upsert({
             where: {


### PR DESCRIPTION
## Summary
Fixes #306 — replaces timing-vulnerable `===` comparison with constant-time `timingSafeEqual`.

## Changes
- Replace direct string comparison with constant-time comparison for admin password
- No behavioral change for valid authentication flows

## CWE Reference
- **CWE-208**: Observable Timing Discrepancy
- Uses stdlib only (`crypto`) — no new dependencies

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*