### PR TITLE
fix: use constant-time comparison for auth token (CWE-208)

### DIFF
--- a/config.server.ts
+++ b/config.server.ts
@@ -1,5 +1,14 @@
+import { timingSafeEqual } from 'crypto'
 import Providers, { AppProviders } from 'next-auth/providers'
 import { prisma, resolvedConfig } from './utils.server'
+
+function safeEqual(a: string, b: string): boolean {
+  try {
+    return timingSafeEqual(Buffer.from(a), Buffer.from(b))
+  } catch {
+    return false
+  }
+}
 
 /**
  * Auth Providers
@@ -27,7 +36,8 @@ if (resolvedConfig.useLocalAuth) {
       async authorize(credentials: { username: string; password: string }) {
         if (
           credentials.username === process.env.USERNAME &&
-          credentials.password === process.env.PASSWORD
+          process.env.PASSWORD &&
+          safeEqual(credentials.password, process.env.PASSWORD)
         ) {
           const user = await prisma.user.upsert({
             where: {


### PR DESCRIPTION
## Summary
Fixes #306 — replaces timing-vulnerable `===` comparison with constant-time `timingSafeEqual`.

## Changes
- Replace direct string comparison with constant-time comparison for admin password
- No behavioral change for valid authentication flows

## CWE Reference
- **CWE-208**: Observable Timing Discrepancy
- Uses stdlib only (`crypto`) — no new dependencies

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*