### PR TITLE
Adds attribute data-style to set custom stylesheet in the iframe

### DIFF
--- a/public/doc/advanced/sdk.md
+++ b/public/doc/advanced/sdk.md
@@ -34,6 +34,13 @@ To embed the comment widget to your web page, you need to put **the element and 
   - `light` (default)
   - `auto` Automatically set theme by `prefers-color-scheme`
   - `dark`
+- `data-style` Add your custom stylesheet directives into the iframe. Example:
+  - data-style="
+        #root { background-color: red !important; padding: 15px !important; border-radius: 8px !important; }
+        label, p { color: yellow !important; font-weight: 600 !important; }
+        input, textarea { background-color: white !important; }
+        button { background-color: blue !important; color: white !important; border: none !important; padding: 8px 16px !important; border-radius: 4px !important; cursor: pointer !important; }
+      "
 
 ## API
 

--- a/widget/iframe.js
+++ b/widget/iframe.js
@@ -13,6 +13,14 @@ const widget = new Widget({
   },
 })
 
+// Inject custom styles passed via data-style attribute into the iframe
+if (dataset && typeof dataset.style === 'string' && dataset.style.trim()) {
+  const styleEl = document.createElement('style')
+  styleEl.type = 'text/css'
+  styleEl.appendChild(document.createTextNode(dataset.style))
+  document.head.appendChild(styleEl)
+}
+
 function postMessage(event, data = {}) {
   parent.postMessage(
     JSON.stringify({

--- a/widget/iframe.js
+++ b/widget/iframe.js
@@ -6,13 +6,6 @@ const parent = window.parent
 const target = document.querySelector('#root')
 
 const dataset = window.__DATA__
-const widget = new Widget({
-  target,
-  props: {
-    attrs: dataset,
-  },
-})
-
 // Inject custom styles passed via data-style attribute into the iframe
 if (dataset && typeof dataset.style === 'string' && dataset.style.trim()) {
   const styleEl = document.createElement('style')
@@ -20,6 +13,13 @@ if (dataset && typeof dataset.style === 'string' && dataset.style.trim()) {
   styleEl.appendChild(document.createTextNode(dataset.style))
   document.head.appendChild(styleEl)
 }
+
+const widget = new Widget({
+  target,
+  props: {
+    attrs: dataset,
+  },
+})
 
 function postMessage(event, data = {}) {
   parent.postMessage(

--- a/widget/index.html
+++ b/widget/index.html
@@ -22,7 +22,7 @@
 <body style="background-color: var(--bg-color);">
   <div style="width: 70%; margin: 0 auto;">
     <div id="cusdis_thread" data-theme="auto" data-page-title="testing" data-iframe="http://localhost:3001/iframe.js" data-host="http://localhost:3000"
-      data-app-id="10ec786a-86b4-4901-a1a8-e47e6d17299d" data-page-id="lalala" data-show-indicator="true"></div>
+      data-app-id="proj-1" data-page-id="lalala" data-show-indicator="true"></div>
     <script src="http://localhost:3000/js/widget/lang/zh-cn.js"></script>
     <script type="module" async src="/index.js"></script>
     <!-- <script async src="http://localhost:3000/js/cusdis.es.js"></script> -->

--- a/widget/index.html
+++ b/widget/index.html
@@ -21,8 +21,16 @@
 
 <body style="background-color: var(--bg-color);">
   <div style="width: 70%; margin: 0 auto;">
-    <div id="cusdis_thread" data-theme="auto" data-page-title="testing" data-iframe="http://localhost:3001/iframe.js" data-host="http://localhost:3000"
-      data-app-id="proj-1" data-page-id="lalala" data-show-indicator="true"></div>
+    <div 
+      id="cusdis_thread" 
+      data-theme="auto" 
+      data-page-title="testing" 
+      data-iframe="http://localhost:3001/iframe.js" 
+      data-host="http://localhost:3000"
+      data-app-id="proj-1" 
+      data-page-id="lalala" 
+      data-show-indicator="true">
+    </div>
     <script src="http://localhost:3000/js/widget/lang/zh-cn.js"></script>
     <script type="module" async src="/index.js"></script>
     <!-- <script async src="http://localhost:3000/js/cusdis.es.js"></script> -->


### PR DESCRIPTION
Outside the iframe  it is not possible to update the stylesheet of single elements. I have patched the code, so it is possible now, with a data-style attribute to be used like the following snippet that I have documented in the "Attributes reference" doc:

```
<div id="cusdis_thread"
      data-host="https://cusdis.com"
      data-app-id="IL_TUO_DATA_APP_ID_QUI"
      data-page-id="{{ .RelPermalink }}"
      data-page-url="{{ .Permalink }}"
      data-page-title="{{ .Title }}"
      data-theme="light"
      data-style="
        #root { background-color: red !important; padding: 15px !important; border-radius: 8px !important; }
        label, p { color: yellow !important; font-weight: 600 !important; }
        input, textarea { background-color: white !important; }
        button { background-color: blue !important; color: white !important; border: none !important; padding: 8px 16px !important; border-radius: 4px !important; cursor: pointer !important; }     
      ">
    </div>
```